### PR TITLE
Move dendritic-unflake to the very bottom.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ flake-parts includes an optional module for storing lower-level modules:
 ## See also
 
 - [vic/dendrix/Dendritic](https://vic.github.io/dendrix/Dendritic.html) - on the benefits of the pattern
-- [vic/den](https://github.com/vic/den) - aspect-oriented Dendritic framework
+- [vic/den](https://github.com/vic/den) - aspect-oriented dendritic framework
 - [vic/dendritic-unflake](https://github.com/vic/dendritic-unflake) - non-flake, non-flake-parts examples
 
 ## Community


### PR DESCRIPTION
Looks like more people are noticing the Dendritic pattern now, and it seems (I've read at least two people mention) that the very first example being my non-flakes repository causes more questions and wrong expectations about it being the *Flagship* example. 

So I've moved the link to dendritic-unflake to the very end, made our dendritic repos highligted as real-world implementations where people can explore the benefits of the pattern. 

I've also added Michael Belsanti repo which is awesome and very well structured. 


Please please merge, it is an issue for me that people expect my non-flakes exploration repo to be the flagship example when it is not.