### PR TITLE
remove bivsk from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Other examples, for which the author cannot vouch:
 - [Pol Dellaiera](https://github.com/drupol/nixos-x260) ([adoption pull request](https://github.com/drupol/nixos-x260/pull/83)) ([blog post](https://not-a-number.io/2025/refactoring-my-infrastructure-as-code-configurations/))
 - [Horizon Haskell](https://gitlab.horizon-haskell.net/nix/gitlab-ci)
 - [Gaétan Lepage](https://github.com/GaetanLepage/nix-config) ([acknowledgment commit](https://github.com/GaetanLepage/nix-config/commit/3ed89eae1a8e13c1910eac5f89f2cdb4f48756ff))
-- [bivsk](https://github.com/bivsk/nix-iv) ([adoption pull request](https://github.com/bivsk/nix-iv/pull/2))
 - [Michael Belsanti](https://tangled.org/quasigod.xyz/nixconfig)
 - [Oliver Davies](https://git.oliverdavies.uk/opdavies/nix-config)
 


### PR DESCRIPTION
This repository has been inactive for a while and likely no longer serves as a great example.